### PR TITLE
Correções no form, create_complaint e help

### DIFF
--- a/app/controllers/complaints_controller.rb
+++ b/app/controllers/complaints_controller.rb
@@ -20,13 +20,22 @@ class ComplaintsController < ApplicationController
   def create
     @complaint = Complaint.new(complaint_params)
     @complaint.user = current_user
-    @complaint_categories_ids = params[:complaint][:categories]
-    @complaint.save
-    @complaint_categories_ids.each do |id|
-      new = ComplaintCategory.new(category_id: id.to_i, complaint_id: @complaint.id)
-      new.save
+    @complaint_categories_ids = params[:complaint][:category_ids]
+    if @complaint.save
+      unless @complaint_categories_ids.nil?
+        @complaint_categories_ids.each do |id|
+          new = ComplaintCategory.new(category_id: id.to_i, complaint_id: @complaint.id)
+          new.save
+        end
+      end
+    else
+      render :new
     end
-    redirect_to root_path, notice: "Denúncia criada com sucesso!"
+    if user_signed_in?
+      redirect_to my_complaints_complaints_path, notice: "Denúncia criada com sucesso!"
+    else
+      redirect_to root_path, notice: "Denúncia criada com sucesso!"
+    end
   end
 
   def edit
@@ -58,5 +67,4 @@ class ComplaintsController < ApplicationController
   def set_complaint
     @complaint = Complaint.find(params[:id])
   end
-
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :home ]
+  skip_before_action :authenticate_user!, only: %i[home help]
 
   def home
   end

--- a/app/views/complaints/_form.html.erb
+++ b/app/views/complaints/_form.html.erb
@@ -177,7 +177,7 @@
               <%= f.association :categories, as: :check_boxes, collection: @cat_aduana, include_hidden: false%>
 
               <p>#CATEGORIAS TRIBUTOS INTERNOS</p>
-              <%= f.input :categories, as: :check_boxes, collection: @cat_trib_int, include_hidden: false %>
+              <%= f.association :categories, as: :check_boxes, collection: @cat_trib_int, include_hidden: false %>
                 <button type="button" id="review_info" class="" data-toggle="modal" data-target="#info">
                   Revisar informações
                 </button>


### PR DESCRIPTION
Ajustes realizados:

- Form Complaints: O código do input da categoria aduana estava diferente da categoria Tributos Internos, uniformizei e conferi o método create.
- create#complaints_controller: Além do ajuste anterior, alterei o create para direcionar para "Minhas denúncias" caso o usuário estiver logado e para "Home" se não estiver logado. Corrigido erro se o usuário não selecionar nenhuma categoria.
- Help: Inseri o skip authorization.

